### PR TITLE
NO-ISSUE: Changing the service to be NodePort

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -64,12 +64,13 @@ objects:
     name: bug-master-service
   spec:
     ports:
-      - name: bug-master-port
-        port: ${{WEBSERVER_PORT}}
-        protocol: TCP
-        targetPort: ${{WEBSERVER_PORT}}
+    - name: bug-master-port
+      port: ${{WEBSERVER_PORT}}
+      protocol: TCP
+      targetPort: ${{WEBSERVER_PORT}}
     selector:
       app: bug-master
+    type: NodePort
            
 parameters:
 - name: IMAGE_NAME


### PR DESCRIPTION
Changing the service to be `NodePort` in attempt to receive requests from outside the cluster in `app-sre`