### PR TITLE
MGMT-14710: Adding a route resource to bug-master

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -70,6 +70,19 @@ objects:
         targetPort: ${{WEBSERVER_PORT}}
     selector:
       app: bug-master
+
+- apiVersion: route.openshift.io/v1
+  kind: Route
+  metadata:
+    labels:
+      app: bug-master
+    name: bug-master-route
+  spec:
+    port:
+      targetPort: ${{WEBSERVER_PORT}}
+    to:
+      kind: Service
+      name: bug-master-service
            
 parameters:
 - name: IMAGE_NAME


### PR DESCRIPTION
Adding a route resource to bug-master in `app-sre` cluster in attempt to expose `bug-master` to requests outside the cluster