### PR TITLE
MGMT-15576: Increase the number of bug-master replicas in app-sre cluster

### DIFF
--- a/openshift/template.yaml
+++ b/openshift/template.yaml
@@ -11,7 +11,7 @@ objects:
     selector:
       matchLabels:
         app: bug-master
-    replicas: 1
+    replicas: 2
     template:
       metadata:
         labels:


### PR DESCRIPTION
`bug-master` occasionally fails to handle the load of incoming requests, therefore we want to add another replica to help handling the load and reduce the probability of down time.