### PR TITLE
NO-ISSUE: Fix unpack exception when container arg does not contain '='

### DIFF
--- a/src/bug_master/prow_job.py
+++ b/src/bug_master/prow_job.py
@@ -35,9 +35,11 @@ class ProwResource:
         variant = ""
 
         container_args = spec.get("pod_spec", {}).get("containers", [{}])[0].get("args", [])
-        for k, v in [a.replace("--", "").split("=") for a in container_args]:
-            if k == "variant":
-                variant = v
+
+        for arg in [a.replace("--", "") for a in container_args]:
+            splitted_arg = arg.split("=")
+            if len(splitted_arg) == 2 and splitted_arg[0] == "variant":
+                variant = splitted_arg[1]
                 break
 
         return ProwResource(full_name, build_id, organization, repo, branch, variant)


### PR DESCRIPTION
Fix unpack exception when container args does not contain '='