### PR TITLE
NO-ISSUE: Increase timeout constant for downloading files

### DIFF
--- a/src/bug_master/consts.py
+++ b/src/bug_master/consts.py
@@ -33,7 +33,7 @@ LOG_LEVEL = int(os.getenv("LOG_LEVEL", logging.DEBUG))
 EVENT_FAILURE_PREFIX = ":red_jenkins_circle:"
 DISABLE_AUTO_ASSIGN_DEFAULT = False
 HTTP_PROTOCOL_TYPE: HTTPProtocolType = os.getenv("HTTP_PROTOCOL_TYPE", default="auto")
-DOWNLOAD_FILE_TIMEOUT = int(os.getenv("DOWNLOAD_FILE_TIMEOUT", default=5))
+DOWNLOAD_FILE_TIMEOUT = int(os.getenv("DOWNLOAD_FILE_TIMEOUT", default=10))
 ENABLE_INITIAL_REPORT = strtobool(os.getenv("ENABLE_INITIAL_REPORT", default="True"))
 
 MB = 1000000


### PR DESCRIPTION
Looks like a lot of bug-master failures is due to prow server being too slow. Increasing the timeout constant for downloading prow resources