### PR TITLE
NO-ISSUE: Enable dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: weekly
+  groups:
+    python-packages:
+      patterns:
+        - "*"


### PR DESCRIPTION
This configures dependabot to check the pip installation for any vulnerabilities and to attempt to fix these if found