### PR TITLE
NO-ISSUE: fixing lint for depndabot

### DIFF
--- a/src/bug_master/middleware.py
+++ b/src/bug_master/middleware.py
@@ -55,7 +55,7 @@ async def exceptions_middleware(request: Request, call_next: RequestResponseEndp
         request.scope["body"] = body
         return await call_next(request)
 
-    except BaseException as e:
+    except Exception as e:
         err = f"Internal server error - {e.__class__.__name__}: {e}"
         consts.logger.error(
             f"{err}, "

--- a/src/bug_master/routes.py
+++ b/src/bug_master/routes.py
@@ -42,7 +42,7 @@ class RouteValidator:
 async def handle_event_exception(event: Event, **kwargs):
     try:
         await event.handle(**kwargs)
-    except BaseException as e:
+    except Exception as e:
         base_err = "Got error while handled event: "
         logger.error(f"{{{event}}} {base_err}, {e.__class__.__name__} {e}")
         if event.user_id:
@@ -53,7 +53,7 @@ async def handle_event_exception(event: Event, **kwargs):
 async def handle_command_exception(command: Command) -> Response:
     try:
         return await command.handle()
-    except BaseException as e:
+    except Exception as e:
         err = f"Got error while handled command {{{command}}}, {e.__class__.__name__} {e}"
         logger.error(err)
 


### PR DESCRIPTION
fix for #37 
lint failure with error
```console
src/bug_master/middleware.py:58:5: B036 Don't except `BaseException` unless you plan to re-raise it.
src/bug_master/routes.py:45:5: B036 Don't except `BaseException` unless you plan to re-raise it.
src/bug_master/routes.py:56:5: B0[36](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift-assisted_bug-master-bot/37/pull-ci-openshift-assisted-bug-master-bot-main-lint/1802735671878619136#1:build-log.txt%3A36) Don't except `BaseException` unless you plan to re-raise it.
```