### PR TITLE
KONFLUX-1611: Add labels, licenses & user to Dockerfile

### DIFF
--- a/.tekton/bug-master-bot-saas-main-pull-request.yaml
+++ b/.tekton/bug-master-bot-saas-main-pull-request.yaml
@@ -30,6 +30,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/.tekton/bug-master-bot-saas-main-push.yaml
+++ b/.tekton/bug-master-bot-saas-main-push.yaml
@@ -27,6 +27,10 @@ spec:
     value: Dockerfile
   - name: path-context
     value: .
+  - name: build-args
+    value:
+    - release={{target_branch}
+    - version={{revision}}
   pipelineSpec:
     finally:
     - name: show-sbom

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,23 @@
 FROM registry.access.redhat.com/ubi9/python-311:latest
 
+ARG release=main
+ARG version=latest
+
+LABEL com.redhat.component bug-master-bot
+LABEL description "Slack bot for handling PROW failures on slack CI channels"
+LABEL summary "Slack bot for handling PROW failures on slack CI channels"
+LABEL io.k8s.description "Slack bot for handling PROW failures on slack CI channels"
+LABEL distribution-scope public
+LABEL name bug-master-bot
+LABEL release ${release}
+LABEL version ${version}
+LABEL url https://github.com/openshift-assisted/bug-master-bot
+LABEL vendor "Red Hat, Inc."
+LABEL maintainer "Red Hat"
+
+# License
+COPY LICENSE /licenses/
+
 COPY --chown=1001:0 . .
 
 RUN pip install --upgrade pip && make install


### PR DESCRIPTION
* Add labels
* Add default user
* Add licenses under /licenses/ (dependencies licenses are not taken)

Requirements come from https://docs.redhat.com/en/documentation/red_hat_software_certification/2024/html-single/red_hat_openshift_software_certification_policy_guide/index#additional_resources and would prevent us from releasing an image (we have an exception for "based_on_ubi image")

